### PR TITLE
Filter irrelevant orgunits

### DIFF
--- a/src/app/app-controller.js
+++ b/src/app/app-controller.js
@@ -7,37 +7,46 @@ function appController(dedupeService, dedupeRecordFilters, $scope, $modal, notif
         ty: 'PURE'
     };
 
-    ctrl.isFilterToggle = false;
-    ctrl.noLoadDone = true;
-    ctrl.isProcessing = false;
-    ctrl.dedupeRecords = [];
-    ctrl.allDedupeRecords = [];
-    ctrl.pager = {
-        current: 1,
-        total: 0,
-        pageSize: DEDUPE_PAGE_SIZE
-    };
-    ctrl.customPageSize = ctrl.pager.pageSize;
-    ctrl.pageToGoTo = ctrl.pager.current;
-    ctrl.goToPage = goToPage;
-    ctrl.maxPageNumber = maxPageNumber;
-    ctrl.maxPageSize = maxPageSize;
+    init();
 
-    //Controller methods
-    ctrl.useMax = useMax;
-    ctrl.useSum = useSum;
-    ctrl.resolveDuplicates = resolveDuplicates;
-    ctrl.changedIncludeResolved = changedIncludeResolved;
-    ctrl.isShowingAll = isShowingAll;
-    ctrl.getDuplicateRecords = getDuplicateRecords;
-    ctrl.pageChanged = pageChanged;
-    ctrl.filters = dedupeRecordFilters;
-    ctrl.showCrossWalkMessage = showCrossWalkMessage;
-    ctrl.isShowingCrosswalkDedupes = isShowingCrosswalkDedupes;
-    ctrl.csvSettings = {
-        url: '',
-        show: false
-    };
+    function init() {
+        ctrl.showOrgUnitFilter = false;
+        ctrl.isFilterToggle = false;
+        ctrl.noLoadDone = true;
+        ctrl.isProcessing = false;
+        ctrl.dedupeRecords = [];
+        ctrl.allDedupeRecords = [];
+        ctrl.pager = {
+            current: 1,
+            total: 0,
+            pageSize: DEDUPE_PAGE_SIZE
+        };
+        ctrl.customPageSize = ctrl.pager.pageSize;
+        ctrl.pageToGoTo = ctrl.pager.current;
+        ctrl.goToPage = goToPage;
+        ctrl.maxPageNumber = maxPageNumber;
+        ctrl.maxPageSize = maxPageSize;
+
+        //Controller methods
+        ctrl.useMax = useMax;
+        ctrl.useSum = useSum;
+        ctrl.resolveDuplicates = resolveDuplicates;
+        ctrl.changedIncludeResolved = changedIncludeResolved;
+        ctrl.isShowingAll = isShowingAll;
+        ctrl.getDuplicateRecords = getDuplicateRecords;
+        ctrl.pageChanged = pageChanged;
+        ctrl.filters = dedupeRecordFilters;
+        ctrl.showCrossWalkMessage = showCrossWalkMessage;
+        ctrl.isShowingCrosswalkDedupes = isShowingCrosswalkDedupes;
+        ctrl.csvSettings = {
+            url: '',
+            show: false
+        };
+    }
+
+    $scope.$on('SELECT_ORGANISATION_UNIT_DIRECTIVE.currentUser', function (event, show) {
+        ctrl.showOrgUnitFilter = show;
+    });
 
     $scope.$on('DEDUPE_DIRECTIVE.resolve', function (event, dedupeRecordId, saveStatus) {
 

--- a/src/index.html
+++ b/src/index.html
@@ -30,7 +30,7 @@
             </div>
             <div class="filters-collapse" collapse="isCollapsed">
                 <div class="filters well">
-                    <div class="organisation-unit row">
+                    <div class="organisation-unit row" ng-show="app.showOrgUnitFilter">
                         <div class="col-sm-12">
                             <organisation-unit-select on-orgunit-selected="app.changeOrgUnit"></organisation-unit-select>
                         </div>

--- a/src/organisationunits/organisationunit-select-directive.js
+++ b/src/organisationunits/organisationunit-select-directive.js
@@ -56,11 +56,11 @@ function organisationUnitSelectDirective(organisationUnitService, currentUserSer
 
             function isGlobalOrgUnit(user) {
                 var isGlobalOrgUnit = false;
-                if (user.dataViewOrganisationUnits &&
-                    user.dataViewOrganisationUnits[0] &&
-                    user.dataViewOrganisationUnits[0].id)
+                var globalOrgUnitId = 'ybg3MO3hcf4';
+
+                if (user.dataViewOrganisationUnits && user.dataViewOrganisationUnits.length )
                 {
-                    isGlobalOrgUnit = user.organisationUnits[0].id === user.dataViewOrganisationUnits[0].id;
+                    isGlobalOrgUnit = !!user.dataViewOrganisationUnits.filter(function(element){return element.id === globalOrgUnitId }).length;
 
                     if (user.organisationUnits.length > 1 || user.dataViewOrganisationUnits.length > 1) {
                         window.console.warn('Detected several organisation units for current user.');

--- a/src/organisationunits/organisationunit-select-directive.js
+++ b/src/organisationunits/organisationunit-select-directive.js
@@ -58,9 +58,9 @@ function organisationUnitSelectDirective(organisationUnitService, currentUserSer
                 var isGlobalOrgUnit = false;
                 var globalOrgUnitId = 'ybg3MO3hcf4';
 
-                if (user.dataViewOrganisationUnits && user.dataViewOrganisationUnits.length )
+                if (user.dataViewOrganisationUnits && user.dataViewOrganisationUnits.length)
                 {
-                    isGlobalOrgUnit = !!user.dataViewOrganisationUnits.filter(function(element){return element.id === globalOrgUnitId }).length;
+                    isGlobalOrgUnit = !!user.dataViewOrganisationUnits.filter(function (element) { return element.id === globalOrgUnitId; }).length;
 
                     if (user.organisationUnits.length > 1 || user.dataViewOrganisationUnits.length > 1) {
                         window.console.warn('Detected several organisation units for current user.');

--- a/src/organisationunits/organisationunit-select-directive.js
+++ b/src/organisationunits/organisationunit-select-directive.js
@@ -8,6 +8,8 @@ function organisationUnitSelectDirective(organisationUnitService, currentUserSer
         templateUrl: 'organisationunits/organisation-select.html',
         link: function (scope) {
             scope.organisationUnit = undefined;
+            scope.isGlobalOrgUnit = isGlobalOrgUnit;
+            scope.isUserHasAnOrgUnit = isUserHasAnOrgUnit;
             scope.selectbox = {
                 items: [],
                 placeholder: 'Select an organisation unit',
@@ -23,9 +25,14 @@ function organisationUnitSelectDirective(organisationUnitService, currentUserSer
                     currentUserService.getCurrentUser()
                         .then(function (currentUser) {
                             if (isUserHasAnOrgUnit(currentUser)) {
-                                scope.organisationUnit = findItemInListById(currentUser.organisationUnits[0].id, scope.selectbox.items);
-
+                                var isGlobal = isGlobalOrgUnit(currentUser);
+                                if (isGlobal) {
+                                    scope.organisationUnit = findItemInListById(currentUser.organisationUnits[0].id, scope.selectbox.items);
+                                } else {
+                                    scope.organisationUnit = {id: currentUser.organisationUnits[0].id};
+                                }
                                 dedupeRecordFilters.changeOrganisationUnit(scope.organisationUnit);
+                                scope.$emit('SELECT_ORGANISATION_UNIT_DIRECTIVE.currentUser', isGlobal);
                             }
                         })
                         .catch(function () {
@@ -46,6 +53,22 @@ function organisationUnitSelectDirective(organisationUnitService, currentUserSer
                     }
                 });
             }
+
+            function isGlobalOrgUnit(user) {
+                var isGlobalOrgUnit = false;
+                if (user.dataViewOrganisationUnits &&
+                    user.dataViewOrganisationUnits[0] &&
+                    user.dataViewOrganisationUnits[0].id)
+                {
+                    isGlobalOrgUnit = user.organisationUnits[0].id === user.dataViewOrganisationUnits[0].id;
+
+                    if (user.organisationUnits.length > 1 || user.dataViewOrganisationUnits.length > 1) {
+                        window.console.warn('Detected several organisation units for current user.');
+                    }
+                }
+                return isGlobalOrgUnit;
+            }
+
         }
     };
 }

--- a/test/specs/app/app-controller_spec.js
+++ b/test/specs/app/app-controller_spec.js
@@ -567,4 +567,13 @@ describe('App controller', function () {
             expect(controller.pageChanged).not.toHaveBeenCalled();
         });
     });
+
+    describe('when received on SELECT_ORGANISATION_UNIT_DIRECTIVE.currentUser event', function () {
+        it('should update showOrgUnitFilter flag', function () {
+            expect(controller.showOrgUnitFilter).toBe(false);
+            $rootScope.$broadcast('SELECT_ORGANISATION_UNIT_DIRECTIVE.currentUser', true);
+            $rootScope.$apply();
+            expect(controller.showOrgUnitFilter).toBe(true);
+        });
+    });
 });

--- a/test/specs/organisationunits/organisationunit-select-directive_spec.js
+++ b/test/specs/organisationunits/organisationunit-select-directive_spec.js
@@ -118,18 +118,18 @@ describe('Organisation unit select directive', function () {
             expect(innerScope.isGlobalOrgUnit).toEqual(jasmine.any(Function));
         });
 
-        it('should return true when current user organisationUnits[0].id and dataViewOrganisationUnits[0].id match', function () {
+        it('should return true when user dataViewOrganisationUnits contains global id "ybg3MO3hcf4"', function () {
             var mockCurrentUser = {
                 organisationUnits: [{id: 'ybg3MO3hcf4'}],
-                dataViewOrganisationUnits: [{id: 'ybg3MO3hcf4'}]
+                dataViewOrganisationUnits: [{id: 'ybg3MO3aaa'}, {id: 'ybg3MO3hcf4'}]
             };
             expect(innerScope.isGlobalOrgUnit(mockCurrentUser)).toBe(true);
         });
 
-        it('should return false when current user organisationUnits[0].id differs from dataViewOrganisationUnits[0].id', function () {
+        it('should return false when user dataViewOrganisationUnits does not contains id "ybg3MO3hcf4"', function () {
             var mockCurrentUser = {
                 organisationUnits: [{id: 'ybg3MO3hc99'}],
-                dataViewOrganisationUnits: [{id: 'ybg3MO3hcf4'}]
+                dataViewOrganisationUnits: [{id: 'ybg3MO3hcaaa'}, {id: 'ybg3MO3hc99'}]
             };
             expect(innerScope.isGlobalOrgUnit(mockCurrentUser)).toBe(false);
         });

--- a/test/specs/organisationunits/organisationunit-select-directive_spec.js
+++ b/test/specs/organisationunits/organisationunit-select-directive_spec.js
@@ -112,4 +112,61 @@ describe('Organisation unit select directive', function () {
             expect(notifyMock.error).toHaveBeenCalledWith('Failed to load current user object');
         });
     });
+
+    describe('isGlobalOrgUnit', function () {
+        it('should be a function', function () {
+            expect(innerScope.isGlobalOrgUnit).toEqual(jasmine.any(Function));
+        });
+
+        it('should return true when current user organisationUnits[0].id and dataViewOrganisationUnits[0].id match', function () {
+            var mockCurrentUser = {
+                organisationUnits: [{id: 'ybg3MO3hcf4'}],
+                dataViewOrganisationUnits: [{id: 'ybg3MO3hcf4'}]
+            };
+            expect(innerScope.isGlobalOrgUnit(mockCurrentUser)).toBe(true);
+        });
+
+        it('should return false when current user organisationUnits[0].id differs from dataViewOrganisationUnits[0].id', function () {
+            var mockCurrentUser = {
+                organisationUnits: [{id: 'ybg3MO3hc99'}],
+                dataViewOrganisationUnits: [{id: 'ybg3MO3hcf4'}]
+            };
+            expect(innerScope.isGlobalOrgUnit(mockCurrentUser)).toBe(false);
+        });
+
+        it('should return false when current user does not have dataViewOrganisationUnits', function () {
+            var mockCurrentUser = {
+                organisationUnits: [{id: 'ybg3MO3hcf4'}]
+            };
+            expect(innerScope.isGlobalOrgUnit(mockCurrentUser)).toBe(false);
+            mockCurrentUser = {
+                organisationUnits: [{id: 'ybg3MO3hcf4'}],
+                dataViewOrganisationUnits: []
+            };
+            expect(innerScope.isGlobalOrgUnit(mockCurrentUser)).toBe(false);
+        });
+    });
+
+    describe('isUserHasAnOrgUnit', function () {
+        it('should be a function', function () {
+            expect(innerScope.isUserHasAnOrgUnit).toEqual(jasmine.any(Function));
+        });
+
+        it('should return false when current user does not have organisationUnits', function () {
+            var mockCurrentUser = {
+                dataViewOrganisationUnits: [{id: 'ybg3MO3hcf4'}]
+            };
+            expect(innerScope.isUserHasAnOrgUnit(mockCurrentUser)).toBeFalsy();
+            mockCurrentUser = {
+                organisationUnits: [],
+                dataViewOrganisationUnits: []
+            };
+            expect(innerScope.isGlobalOrgUnit(mockCurrentUser)).toBeFalsy();
+            mockCurrentUser = {
+                organisationUnits: [{}],
+                dataViewOrganisationUnits: []
+            };
+            expect(innerScope.isGlobalOrgUnit(mockCurrentUser)).toBeFalsy();
+        });
+    });
 });


### PR DESCRIPTION
Select organisation unit filter should only be displayed when `organisationUnits[0].id === dataViewOrganisationUnits[0].id`

Otherwise no organisation unit filter should be displayed and `organisationUnits[0].id` is used on following requests.


