### PR TITLE
Feature: DEG and Agency filter

### DIFF
--- a/sql/app/dedupe_plpgsql.sql
+++ b/sql/app/dedupe_plpgsql.sql
@@ -26,6 +26,9 @@ startdate timestamp with time zone;
 enddate timestamp with time zone;
 good_to_go boolean;
 period_exists boolean;
+degfilter ALIAS FOR $8;
+agfilter ALIAS for $9;
+
  BEGIN
 --Validation
 
@@ -86,12 +89,12 @@ END IF;
 
 -- Validate the DEG filter
 EXECUTE 'SELECT ''' || $8 || '''  IN (SELECT DISTINCT shortname from dataelementgroup);' into this_exists;
-IF this_exists != true THEN
+IF this_exists != true AND degfilter != '' THEN 
   RAISE EXCEPTION 'Invalid data element group filter!';
 END IF;
 --Validate the agency filter
 EXECUTE 'SELECT ''' || $9 || '''  IN (SELECT DISTINCT uid from categoryoptiongroup);' into this_exists;
-IF this_exists != true THEN
+IF this_exists != true AND agfilter != '' THEN
   RAISE EXCEPTION 'Invalid agency filter!';
 END IF;
 

--- a/sql/app/dedupe_plpgsql.sql
+++ b/sql/app/dedupe_plpgsql.sql
@@ -6,8 +6,8 @@ boolean,integer,integer,character varying,character varying,character varying);
 
 CREATE OR REPLACE FUNCTION view_duplicates(ou character (11),pe character varying(15),rs boolean default false,
 ps integer default 50,pg integer default 1,dt character varying(50) default 'ALL',ty character varying(50) default 'PURE',
-degfilter character varying(50) default '',
-agfilter character varying(50) default '') 
+degfilter character varying(50) default 'NONE',
+agfilter character varying(50) default 'NONE') 
 RETURNS setof duplicate_records AS  $$
  DECLARE
  returnrec duplicate_records;
@@ -89,12 +89,12 @@ END IF;
 
 -- Validate the DEG filter
 EXECUTE 'SELECT ''' || $8 || '''  IN (SELECT DISTINCT shortname from dataelementgroup);' into this_exists;
-IF this_exists != true AND degfilter != '' THEN 
+IF this_exists != true AND degfilter != 'NONE' THEN 
   RAISE EXCEPTION 'Invalid data element group filter!';
 END IF;
 --Validate the agency filter
 EXECUTE 'SELECT ''' || $9 || '''  IN (SELECT DISTINCT uid from categoryoptiongroup);' into this_exists;
-IF this_exists != true AND agfilter != '' THEN
+IF this_exists != true AND agfilter != 'NONE' THEN
   RAISE EXCEPTION 'Invalid agency filter!';
 END IF;
 
@@ -124,7 +124,7 @@ END CASE;
 
 
 CASE COALESCE(degfilter,'')
- WHEN '' THEN
+ WHEN 'NONE' THEN
  deg_filter := ' ';
  ELSE
 deg_filter := ' AND dataelementid in (SELECT dataelementid from dataelementgroupmembers 
@@ -413,8 +413,8 @@ IF this_exists = TRUE THEN
 --Apply the agency filter
 
 
-CASE COALESCE(agfilter,'')
- WHEN '' THEN
+CASE COALESCE(agfilter,'NONE')
+ WHEN 'NONE' THEN
  ELSE
    EXECUTE 'DELETE from temp1 
    WHERE (dataelementid,categoryoptioncomboid,sourceid,periodid) NOT IN 


### PR DESCRIPTION
Based on some feature requests during DEVCON and from ZenDesk, add the ability to feature dedupes by technical area as well as Agency. 

This PR implements the required backend changes. 

- Supply a technical area shortname (TX_CURR)  as a parameter
- Supply an agency UID as a parameter